### PR TITLE
AnalyzerFormatter can use a custom RSpec configuration value to only display analysis for recent failure history

### DIFF
--- a/lib/rspec_log_formatter/analyzer_formatter.rb
+++ b/lib/rspec_log_formatter/analyzer_formatter.rb
@@ -5,15 +5,54 @@ module RspecLogFormatter
   class AnalyzerFormatter < RSpec::Core::Formatters::BaseFormatter
     FILENAME = "rspec.history"
 
+    RSpec.configure { |c| c.add_setting :num_days_to_analyze }
+
     def initialize(*args)
       super
     end
 
     def dump_summary(_,_,_,_)
+      if recent_cutoff_line.nil?
+        display_full_analysis
+      else
+        display_partial_analysis(recent_cutoff_line)
+      end
+    end
+
+    def recent_cutoff_line
+      @recent_cutoff_line ||= begin
+        if num_days_to_analyze
+          cutoff_date = (last_day_to_analyze - num_days_to_analyze).to_s
+          File.readlines(FILENAME).index { |x| x.include? cutoff_date }
+        end
+      end
+    end
+
+    def display_full_analysis
+      display_analysis_using_file(FILENAME)
+    end
+
+    def display_partial_analysis(cutoff_line)
+      Tempfile.open(FILENAME + ".partial") do |file|
+        `sed "1,#{cutoff_line}d" #{FILENAME} > #{file.path}`
+        display_analysis_using_file(file.path)
+      end
+    end
+
+    private
+
+    def display_analysis_using_file(file_path)
       output.puts RspecLogFormatter::Analysis::PrettyPrinter.new(
-        RspecLogFormatter::Analysis::Analyzer.new.analyze(FILENAME)
+        RspecLogFormatter::Analysis::Analyzer.new.analyze(file_path)
       )
     end
 
+    def num_days_to_analyze
+      RSpec.configuration.num_days_to_analyze
+    end
+
+    def last_day_to_analyze
+      Date.today
+    end
   end
 end

--- a/lib/rspec_log_formatter/analyzer_formatter.rb
+++ b/lib/rspec_log_formatter/analyzer_formatter.rb
@@ -9,7 +9,6 @@ module RspecLogFormatter
       super
     end
 
-
     def dump_summary(_,_,_,_)
       output.puts RspecLogFormatter::Analysis::PrettyPrinter.new(
         RspecLogFormatter::Analysis::Analyzer.new.analyze(FILENAME)

--- a/spec/fixtures/varying_flakiness_over_days.history
+++ b/spec/fixtures/varying_flakiness_over_days.history
@@ -1,0 +1,10 @@
+1	2014-01-21 16:08:25 -0800	failed	desc1	./spec/m1k1_spec.rb	msg10	ec10
+1	2014-01-21 16:08:25 -0800	failed	desc2	./spec/m1k1_spec.rb	msg10	ec10
+1	2014-01-21 16:08:25 -0800	failed	desc3	./spec/m1k1_spec.rb	msg10	ec10
+1	2014-01-22 16:08:25 -0800	failed	desc1	./spec/m1k1_spec.rb	msg10	ec10
+1	2014-01-22 16:08:25 -0800	failed	desc2	./spec/m1k1_spec.rb	msg10	ec10
+1	2014-01-22 16:08:25 -0800	failed	desc3	./spec/m1k1_spec.rb	msg10	ec10
+1	2014-01-23 16:08:25 -0800	passed	desc1	./spec/m1k1_spec.rb
+1	2014-01-23 16:08:25 -0800	passed	desc2	./spec/m1k1_spec.rb
+1	2014-01-23 16:08:25 -0800	failed	desc3	./spec/m1k1_spec.rb	msg10	ec10
+1	2014-01-23 16:08:25 -0800	passed	desc3	./spec/m1k1_spec.rb

--- a/spec/lib/rspec_log_analyzer/analyzer_formatter_spec.rb
+++ b/spec/lib/rspec_log_analyzer/analyzer_formatter_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
-describe RspecLogFormatter::Formatter do
-
+describe RspecLogFormatter::AnalyzerFormatter do
 
   it "works" do
     filepath = File.expand_path("../../../fixtures/varying_flakiness.history", __FILE__)

--- a/spec/lib/rspec_log_analyzer/analyzer_formatter_spec.rb
+++ b/spec/lib/rspec_log_analyzer/analyzer_formatter_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe RspecLogFormatter::AnalyzerFormatter do
+  let(:out) { StringIO.new }
+  subject(:formatter) { described_class.new(out) }
 
   it "works" do
     filepath = File.expand_path("../../../fixtures/varying_flakiness.history", __FILE__)
     FileUtils.cp(filepath, 'rspec.history')
-    out = StringIO.new
-    formatter = RspecLogFormatter::AnalyzerFormatter.new(out)
     formatter.dump_summary(1,2,3,4)
     out.rewind
     out.read.should == <<HEREDOC
@@ -27,5 +27,106 @@ Top 3 flakiest examples
     * ec10
       msg10
 HEREDOC
+  end
+
+  describe "varying the length of history to analyze" do
+    let(:file_path) { File.expand_path("../../../fixtures/varying_flakiness_over_days.history", __FILE__) }
+    before { FileUtils.cp(file_path, "rspec.history") }
+
+    context "when no number of days is specified" do
+      it "displays analysis of the full history" do
+        formatter.dump_summary(1,2,3,4)
+        out.rewind
+        out.read.should == <<HEREDOC
+Top 3 flakiest examples
+  1) desc3 -- 75.0%
+    * ec10
+      msg10
+    * ec10
+      msg10
+    * ec10
+      msg10
+  2) desc2 -- 66.66666666666667%
+    * ec10
+      msg10
+    * ec10
+      msg10
+  3) desc1 -- 66.66666666666667%
+    * ec10
+      msg10
+    * ec10
+      msg10
+HEREDOC
+      end
+    end
+
+    context "when the number of days is specified" do
+      # Stubbing object under test :(, but avoids setting RSpec configuration in test
+      before { subject.stub(num_days_to_analyze: num_days_to_analyze) }
+
+      # Stubbing Date :(, but can't pass date in as dependency since class must
+      #   conform to Formatter interface
+      before { Date.stub(today: Date.parse("2014-01-24 16:08:25")) }
+
+      context "when there was a test run that number of days ago" do
+        let(:num_days_to_analyze) { 2 }
+
+        it "displays analysis of the history from that many days ago" do
+          formatter.dump_summary(1,2,3,4)
+          out.rewind
+          out.read.should == <<HEREDOC
+Top 3 flakiest examples
+  1) desc3 -- 66.66666666666667%
+    * ec10
+      msg10
+    * ec10
+      msg10
+  2) desc2 -- 50.0%
+    * ec10
+      msg10
+  3) desc1 -- 50.0%
+    * ec10
+      msg10
+HEREDOC
+        end
+      end
+
+      context "when the oldest test run happened more recently than that many days ago" do
+        let(:num_days_to_analyze) { 4 }
+
+        it "displays analysis of the full history" do
+          formatter.dump_summary(1,2,3,4)
+          out.rewind
+          out.read.should == <<HEREDOC
+Top 3 flakiest examples
+  1) desc3 -- 75.0%
+    * ec10
+      msg10
+    * ec10
+      msg10
+    * ec10
+      msg10
+  2) desc2 -- 66.66666666666667%
+    * ec10
+      msg10
+    * ec10
+      msg10
+  3) desc1 -- 66.66666666666667%
+    * ec10
+      msg10
+    * ec10
+      msg10
+HEREDOC
+        end
+      end
+
+      context "when the most recent test run happened more than that many days ago" do
+        pending "displays message that there are no recent tests to analyze"
+      end
+
+      context "when the specified number of days is invalid" do
+        pending "displays message warning that the specified number of days is invalid"
+      end
+    end
   end
 end


### PR DESCRIPTION
This is useful for performance, as analyzing the history of a few weeks of continuous builds can take very long.  This is also very useful for weighting recency more heavily, as a test that has been flaky for months but recently been fixed will soon cease to show up at the top of the list of flakiest tests.
